### PR TITLE
Add instructions to conda install CUDA toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ To ensure maximum reproducibility, consider creating a new conda environment:
 conda create -n minillm
 conda activate minillm
 conda install git pip virtualenv
+# if you have not already installed CUDA in your system environment
+# so that, for instance, nvcc is not in your PATH, then also:
+conda install -c "nvidia/label/cuda-11.6.2" cuda-toolkit
 ```
 MiniLLM also requries an NVIDIA GPU (Pascal architecture or newer); other platforms are currently unsupported.
 


### PR DESCRIPTION
My system only has NVIDIA drivers installed, not CUDA, so I needed to install CUDA explicitly within the condo environment for the rest of your setup instructions to work.

FWIW, in the end I used condo but not virtualenv, which I think may be superfluous if you're already using conda. Another small thing that tripped me up is that your instructions assume, but never state, that the user should clone the repo and change into the repo's directory before running them.

I managed to get it working on a Debian 11 system with a GeFOrce RTX 3070, which has 8 GB of memory.

I look forward to following this project!